### PR TITLE
Enable support for months and years

### DIFF
--- a/pytimeparse/timeparse.py
+++ b/pytimeparse/timeparse.py
@@ -34,8 +34,8 @@ kinds of time expressions.
 import re
 
 SIGN        = r'(?P<sign>[+|-])?'
-#YEARS      = r'(?P<years>\d+)\s*(?:ys?|yrs?.?|years?)'
-#MONTHS     = r'(?P<months>\d+)\s*(?:mos?.?|mths?.?|months?)'
+YEARS       = r'(?P<years>\d+)\s*(?:ys?|yrs?.?|years?)'
+MONTHS      = r'(?P<months>\d+)\s*(?:mos?.?|mths?.?|months?)'
 WEEKS       = r'(?P<weeks>[\d.]+)\s*(?:w|wks?|weeks?)'
 DAYS        = r'(?P<days>[\d.]+)\s*(?:d|dys?|days?)'
 HOURS       = r'(?P<hours>[\d.]+)\s*(?:h|hrs?|hours?)'
@@ -54,8 +54,8 @@ OPTSEP      = lambda x: r'(?:{x}\s*(?:{SEPARATORS}\s*)?)?'.format(
 
 TIMEFORMATS = [
     r'{WEEKS}\s*{DAYS}\s*{HOURS}\s*{MINS}\s*{SECS}'.format(
-        #YEARS=OPTSEP(YEARS),
-        #MONTHS=OPTSEP(MONTHS),
+        YEARS=OPTSEP(YEARS),
+        MONTHS=OPTSEP(MONTHS),
         WEEKS=OPTSEP(WEEKS),
         DAYS=OPTSEP(DAYS),
         HOURS=OPTSEP(HOURS),
@@ -71,10 +71,10 @@ TIMEFORMATS = [
         DAYCLOCK=DAYCLOCK),
     r'{SECCLOCK}'.format(
         SECCLOCK=SECCLOCK),
-    #r'{YEARS}'.format(
-        #YEARS=YEARS),
-    #r'{MONTHS}'.format(
-        #MONTHS=MONTHS),
+    r'{YEARS}'.format(
+        YEARS=YEARS),
+    r'{MONTHS}'.format(
+        MONTHS=MONTHS),
     ]
 
 COMPILED_SIGN = re.compile(r'\s*' + SIGN + r'\s*(?P<unsigned>.*)$')
@@ -82,8 +82,8 @@ COMPILED_TIMEFORMATS = [re.compile(r'\s*' + timefmt + r'\s*$', re.I)
                         for timefmt in TIMEFORMATS]
 
 MULTIPLIERS = dict([
-        #('years',  60 * 60 * 24 * 365),
-        #('months', 60 * 60 * 24 * 30),
+        ('years',  60 * 60 * 24 * 365),
+        ('months', 60 * 60 * 24 * 30),
         ('weeks',   60 * 60 * 24 * 7),
         ('days',    60 * 60 * 24),
         ('hours',   60 * 60),
@@ -106,8 +106,8 @@ def _interpret_as_minutes(sval, mdict):
         and (('hours' not in mdict) or (mdict['hours'] is None))
         and (('days' not in mdict) or (mdict['days'] is None))
         and (('weeks' not in mdict) or (mdict['weeks'] is None))
-        #and (('months' not in mdict) or (mdict['months'] is None))
-        #and (('years' not in mdict) or (mdict['years'] is None))
+        and (('months' not in mdict) or (mdict['months'] is None))
+        and (('years' not in mdict) or (mdict['years'] is None))
         ):   
         mdict['hours'] = mdict['mins']
         mdict['mins'] = mdict['secs']


### PR DESCRIPTION
Dear Will,

first things first: Thanks a stack for conceiving this excellent package.

Attaching to #7 and #13, while recognizing your arguments, I still believe it would be reasonable to assume "30 days for a month" and "365 days for a year" as the basis for calculations with those units. I agree that this approximation should be documented well.

Based on what has been done with #10 by @duramato, this patch activates the corresponding lines.

With kind regards,
Andreas.
