### PR TITLE
Remove deprecated codecs.open

### DIFF
--- a/pytimeparse/__init__.py
+++ b/pytimeparse/__init__.py
@@ -9,7 +9,6 @@ __init__.py
 '''
 
 from __future__ import absolute_import
-from codecs import open
 from os import path
 
 # Version. For each new release, the version number should be updated

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ distutils setup script for pytimeparse.
 '''
 
 from setuptools import setup, find_packages  # Always prefer setuptools over distutils
-from codecs import open  # To use a consistent encoding
 from os import path
 
 HERE = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
`codecs.open()` has been deprectated in Python 3.14, and regular `open()` has been able to do the same things for a long time.